### PR TITLE
Make input constraints follow MDC 2015 spec.

### DIFF
--- a/driver/SamsungMDC.js
+++ b/driver/SamsungMDC.js
@@ -2,7 +2,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -36,7 +36,7 @@ define(["require", "exports", "system_lib/Driver", "system_lib/Metadata"], funct
             socket.enableWakeOnLAN();
             _this.propList = [];
             _this.propList.push(_this.powerProp = new Power(_this));
-            _this.inputProp = new NumProp(_this, "input", "Source input number; HDMI1=33", 0x14, 0x21, 0x14, 0x40);
+            _this.inputProp = new NumProp(_this, "input", "Source input number; HDMI1=33", 0x14, 0x21, 0x04, 0x64);
             _this.propList.push(_this.inputProp);
             _this.propList.push(_this.volumeProp = new Volume(_this));
             socket.subscribe('connect', function (sender, message) {

--- a/driver/SamsungMDC.ts
+++ b/driver/SamsungMDC.ts
@@ -69,7 +69,7 @@ export class SamsungMDC extends Driver<NetworkTCP> {
 		this.inputProp = new NumProp(this,
 			"input", "Source input number; HDMI1=33",
 			0x14, 0x21,
-			0x14, 0x40
+			0x04, 0x64
 		);
 		this.propList.push(this.inputProp);
 		this.propList.push(this.volumeProp = new Volume(this));

--- a/driver/SamsungMDCBasic.js
+++ b/driver/SamsungMDCBasic.js
@@ -2,7 +2,7 @@ var __extends = (this && this.__extends) || (function () {
     var extendStatics = function (d, b) {
         extendStatics = Object.setPrototypeOf ||
             ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
-            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
         return extendStatics(d, b);
     };
     return function (d, b) {
@@ -122,8 +122,8 @@ define(["require", "exports", "system_lib/Driver", "system_lib/Metadata"], funct
         ], SamsungMDCBasic.prototype, "volume", null);
         __decorate([
             Metadata_1.property("Input (source) number. HDMI1=0x21. HDMI2=0x22"),
-            Metadata_1.min(0x14),
-            Metadata_1.max(0x40),
+            Metadata_1.min(0x04),
+            Metadata_1.max(0x64),
             __metadata("design:type", Number),
             __metadata("design:paramtypes", [Number])
         ], SamsungMDCBasic.prototype, "input", null);

--- a/driver/SamsungMDCBasic.ts
+++ b/driver/SamsungMDCBasic.ts
@@ -63,7 +63,7 @@ export class SamsungMDCBasic extends Driver<NetworkTCP> {
 	}
 
 	@property("Input (source) number. HDMI1=0x21. HDMI2=0x22")
-	@min(0x14) @max(0x40) // Somewhat arbitrary constraints
+	@min(0x04) @max(0x64) // Constraints based on MDC spec 2015
 	public set input(
 		input: number
 	) {


### PR DESCRIPTION
Most importantly allow input 0x63 (decimal 99) which is the URL Launcher (used for the Blocks Player).