### PR TITLE
Clean up QSYS.ts to remove "implicit any" warnings, add typings for split-string

### DIFF
--- a/driver-archive/QSYS.ts
+++ b/driver-archive/QSYS.ts
@@ -4,7 +4,8 @@
 import {NetworkTCP} from "system/Network";
 import {Driver} from "system_lib/Driver";
 import * as Meta from "system_lib/Metadata";
-const split:any = require("lib/split-string");
+import {State} from "lib/split-string";
+const split = require("lib/split-string");
 
 /**
  This driver talks to a QSC Q-Sys core via TCP using the Q-SYS External Control
@@ -42,6 +43,11 @@ interface Prop {
 	propertyName: string;
 	mapping: Mapping;
 	value: number;
+}
+
+/* Hack for bracket access to @Meta.properties without TypeScript errors */
+export interface QSYS extends Driver<NetworkTCP> {
+	[key: string]: any;
 }
 
 @Meta.driver('NetworkTCP', { port: 1702 })
@@ -315,8 +321,8 @@ export class QSYS extends Driver<NetworkTCP> {
 	 intact, unless the quote is escaped with \.
 	 Then strip unescaped quotes from the resulting pieces.
 	 */
-	private parseReply(reply: string) : string {
-		let keep = (value, state) => {
+	private parseReply(reply: string) : string[] {
+		let keep = (value: string, state: State) => {
 			return value !== '\\' && (value !== '"' || state.prev() === '\\');
 		};
 		return split(reply, { quotes: ['"'], separator: ' ', keep: keep });

--- a/lib/split-string.d.ts
+++ b/lib/split-string.d.ts
@@ -1,0 +1,38 @@
+// TypeScript Version: 3.0
+
+/* From: https://github.com/jonschlinkert/split-string
+ * Copyright (c) 2019, Jon Schlinkert. Released under the MIT License.
+ */
+
+
+
+export interface ASTNode {
+  type: 'root' | 'bracket';
+  nodes: ASTNode[];
+  stash: string[];
+}
+
+export interface State {
+  input: string;
+  separator: string;
+  stack: ASTNode[];
+  bos(): boolean;
+  eos(): boolean;
+  prev(): string;
+  next(): string;
+}
+
+export interface Options {
+  brackets?: { [key: string]: string } | boolean;
+  quotes?: string[] | boolean;
+  separator?: string;
+  strict?: boolean;
+  keep?(value: string, state: State): boolean;
+}
+
+type SplitFunc = (state: State) => boolean;
+
+declare function split(input: string, options?: Options | SplitFunc): string[];
+declare function split(input: string, options: Options, fn: SplitFunc): string[];
+
+export default split;


### PR DESCRIPTION
As mentioned in #19.

No .js file in commit, as it is unchanged.