### PR TITLE
Bundle suncalc type definitions

### DIFF
--- a/lib-archive/suncalc.d.ts
+++ b/lib-archive/suncalc.d.ts
@@ -1,0 +1,49 @@
+// Type definitions for suncalc 1.9
+// Project: https://github.com/mourner/suncalc
+// Definitions by: horiuchi <https://github.com/horiuchi>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+export interface GetTimesResult {
+    dawn: Date;
+    dusk: Date;
+    goldenHour: Date;
+    goldenHourEnd: Date;
+    nadir: Date;
+    nauticalDawn: Date;
+    nauticalDusk: Date;
+    night: Date;
+    nightEnd: Date;
+    solarNoon: Date;
+    sunrise: Date;
+    sunriseEnd: Date;
+    sunset: Date;
+    sunsetStart: Date;
+}
+export interface GetSunPositionResult {
+    altitude: number;
+    azimuth: number;
+}
+export interface GetMoonPositionResult {
+    altitude: number;
+    azimuth: number;
+    distance: number;
+    parallacticAngle: number;
+}
+export interface GetMoonIlluminationResult {
+    fraction: number;
+    phase: number;
+    angle: number;
+}
+export interface GetMoonTimes {
+    rise: Date;
+    set: Date;
+    alwaysUp?: true;
+    alwaysDown?: true;
+}
+
+export function getTimes(date: Date, latitude: number, longitude: number, height?: number): GetTimesResult;
+export function addTime(angleInDegrees: number, morningName: string, eveningName: string): void;
+export function getPosition(timeAndDate: Date, latitude: number, longitude: number): GetSunPositionResult;
+export function getMoonPosition(timeAndDate: Date, latitude: number, longitude: number): GetMoonPositionResult;
+export function getMoonIllumination(timeAndDate: Date): GetMoonIlluminationResult;
+export function getMoonTimes(date: Date, latitude: number, longitude: number, inUTC?: boolean): GetMoonTimes;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,24 @@
 {
   "name": "script",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@types/suncalc": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@types/suncalc/-/suncalc-1.8.1.tgz",
-      "integrity": "sha512-PNtzFQhdAIw3x5HEjVMxbyBwciX42C/Cg6J1foq2z/t9rucLGGu9nqQxOl005wGZR/fOxw49exwZUCmbnT/vGw=="
+  "packages": {
+    "": {
+      "name": "script",
+      "version": "1.0.0",
+      "license": "Copyright (c) PIXILAB Technologies AB, Sweden. All Rights Reserved.",
+      "dependencies": {
+        "reflect-metadata": "^0.1.10"
+      }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
+      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
+    }
+  },
+  "dependencies": {
     "reflect-metadata": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "author": "PIXILAB",
   "license": "Copyright (c) PIXILAB Technologies AB, Sweden. All Rights Reserved.",
   "dependencies": {
-    "reflect-metadata": "^0.1.10",
-    "@types/suncalc": "^1.8.1"
+    "reflect-metadata": "^0.1.10"
   }
 }

--- a/user-archive/SunAngle.ts
+++ b/user-archive/SunAngle.ts
@@ -9,7 +9,7 @@
 
 import { property} from "system_lib/Metadata"
 import {Script, ScriptEnv} from "system_lib/Script";
-import * as SunCalc from "suncalc";
+import * as SunCalc from "lib-archive/suncalc";
 
 const suncalc: typeof SunCalc = require("lib/suncalc");
 

--- a/user-archive/SunClock.ts
+++ b/user-archive/SunClock.ts
@@ -9,7 +9,7 @@
 
 import {callable, parameter, property} from "system_lib/Metadata"
 import {Script, ScriptEnv} from "system_lib/Script";
-import * as SunCalc from "suncalc";
+import * as SunCalc from "lib-archive/suncalc";
 
 const suncalc: typeof SunCalc = require("lib/suncalc");
 


### PR DESCRIPTION
Bundle `suncalc` type defs to workaround #27, as proposed.

Also fixes the imports in `SunAngle.ts` and `SunClock.ts`.

This also bumps `lockfileVersion` to `2`. Can rebuild if needed, but then again the last Node/NPM version to use v1 lockfiles is out of security support since June 2021.