### PR TITLE
Added MetricsProvider for integrations with Matomo

### DIFF
--- a/user-archive/MetricsProvider.js
+++ b/user-archive/MetricsProvider.js
@@ -1,0 +1,372 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        if (typeof b !== "function" && b !== null)
+            throw new TypeError("Class extends value " + String(b) + " is not a constructor or null");
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (g && (g = 0, op[0] && (_ = 0)), _) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+define(["require", "exports", "system/Spot", "system_lib/Script", "system/SimpleHTTP", "system/SimpleFile", "system_lib/Metadata"], function (require, exports, Spot_1, Script_1, SimpleHTTP_1, SimpleFile_1, Meta) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.MetricsProvider = void 0;
+    var DEFAULT_SETTINGS = {
+        LOGGING_ENABLED: false,
+        SYSTEM_NAME: "PIXILAB",
+        COUNTRY: "Sweden",
+        CITY: "Linkoping",
+        TRACKER_URL: "https://yourdomain/matomo.php",
+        TRACKED_URL: "http://your_blocks_server",
+        ACCESS_TOKEN: "",
+        SITE_ID: 1,
+        MAX_QUEUE_LENGTH: 50,
+        MAX_SEND_INTERVALL: 1000 * 60,
+        LANGUAGE_TAG_MAPPING: {
+            se: "Swedish",
+            en: "English",
+            es: "Spanish",
+            de: "German"
+        }
+    };
+    var API_VERSION = 1;
+    var CONFIG_FILE = "MetricsProviderSettings.json";
+    var settings = DEFAULT_SETTINGS;
+    var MetricsProvider = (function (_super) {
+        __extends(MetricsProvider, _super);
+        function MetricsProvider(env) {
+            var _this = _super.call(this, env) || this;
+            _this.messageQueue = {
+                requests: [],
+                token_auth: settings.ACCESS_TOKEN
+            };
+            _this.readSettingsFromFile();
+            return _this;
+        }
+        MetricsProvider.prototype.readSettingsFromFile = function () {
+            var _this = this;
+            SimpleFile_1.SimpleFile.readJson(CONFIG_FILE).then(function (data) {
+                try {
+                    settings = data;
+                    if (settings) {
+                        _this.getAllSpots(Spot_1.Spot);
+                    }
+                }
+                catch (parseError) {
+                    console.error("Failed parsing JSON data from file", CONFIG_FILE, parseError);
+                }
+            }).catch(function (error) {
+                console.log(error + " Could not find config, trying to write example file to script/files/ " + CONFIG_FILE);
+                SimpleFile_1.SimpleFile.write(CONFIG_FILE + ".example", JSON.stringify(DEFAULT_SETTINGS, null, 2))
+                    .then(function () {
+                    console.log("Example config file with default values written successfully");
+                    _this.readSettingsFromFile();
+                })
+                    .catch(function (error) {
+                    console.error("Failed writing file:", CONFIG_FILE, error);
+                });
+            });
+        };
+        MetricsProvider.prototype.getAllSpots = function (spotGroup) {
+            var spotGroupItems = spotGroup;
+            for (var item in spotGroupItems) {
+                var spotGroupItem = spotGroupItems[item];
+                var displaySpot = spotGroupItem.isOfTypeName("DisplaySpot");
+                if (displaySpot) {
+                    log("Found displayspot: " + spotGroupItem.fullName);
+                    new TrackedSpot(spotGroupItem, this);
+                }
+                else {
+                    var spotGroup_1 = spotGroupItem.isOfTypeName("SpotGroup");
+                    if (spotGroup_1) {
+                        log("Found spotgroup: " + spotGroupItem.fullName + " find spots recursive");
+                        this.getAllSpots(spotGroupItem);
+                    }
+                }
+            }
+        };
+        MetricsProvider.prototype.recreateTrackedSpot = function (spotPath) {
+            var spotPathWithoutSpot = spotPath.replace(/^Spot\./, '');
+            if (Spot_1.Spot[spotPathWithoutSpot]) {
+                log("Recreated spot: " + spotPathWithoutSpot);
+                new TrackedSpot(Spot_1.Spot[spotPathWithoutSpot], this);
+            }
+        };
+        MetricsProvider.prototype.getCurrentTime = function () {
+            var now = new Date();
+            var hours = now.getHours();
+            var minutes = now.getMinutes();
+            var seconds = now.getSeconds();
+            return { h: hours, m: minutes, s: seconds };
+        };
+        MetricsProvider.prototype.createMatomoMsg = function (actionName, url, id) {
+            var time = this.getCurrentTime();
+            var message = {
+                idsite: settings.SITE_ID,
+                rec: 1,
+                action_name: actionName,
+                url: url,
+                cid: id,
+                rand: Math.floor(Math.random() * 10000),
+                apiv: API_VERSION,
+                h: time.h,
+                m: time.m,
+                s: time.s,
+            };
+            this.queueMessage(message);
+        };
+        MetricsProvider.prototype.queueMessage = function (message) {
+            var _this = this;
+            var newMessage = '?' + Object.keys(message)
+                .map(function (key) { return "".concat(key, "=").concat(message[key]); })
+                .join('&');
+            this.messageQueue.requests.push(newMessage);
+            log("Queued a new message: " + newMessage);
+            log("Queue is now: " + this.messageQueue.requests.length);
+            if (!this.messageInterval) {
+                this.messageInterval = wait(settings.MAX_SEND_INTERVALL);
+                this.messageInterval.then(function () {
+                    _this.messageInterval.cancel();
+                    _this.messageInterval = undefined;
+                    _this.sendMessageQueue();
+                });
+            }
+            if (this.messageQueue.requests.length >= settings.MAX_QUEUE_LENGTH) {
+                this.sendMessageQueue();
+                this.messageQueue.requests = [];
+                if (this.messageInterval) {
+                    this.messageInterval.cancel();
+                    this.messageInterval = undefined;
+                }
+            }
+        };
+        MetricsProvider.prototype.sendMessageQueue = function () {
+            return __awaiter(this, void 0, void 0, function () {
+                var tempQueue, request;
+                return __generator(this, function (_a) {
+                    tempQueue = __assign({}, this.messageQueue);
+                    this.messageQueue.requests = [];
+                    log("Sending outgoing message: " + JSON.stringify(tempQueue));
+                    request = SimpleHTTP_1.SimpleHTTP.newRequest(settings.TRACKER_URL);
+                    return [2, request.post(JSON.stringify(tempQueue), 'application/json')
+                            .catch(function (error) {
+                            console.error("Connection to the tracker failed:", error);
+                        })];
+                });
+            });
+        };
+        MetricsProvider.prototype.reinit = function () {
+            this.reInitialize();
+        };
+        MetricsProvider.prototype.getTagMappedFullName = function (key) {
+            var lowercaseKey = key.toLowerCase();
+            if (lowercaseKey in settings.LANGUAGE_TAG_MAPPING) {
+                return settings.LANGUAGE_TAG_MAPPING[lowercaseKey];
+            }
+            else {
+                return undefined;
+            }
+        };
+        __decorate([
+            Meta.callable("Reinitialize script"),
+            __metadata("design:type", Function),
+            __metadata("design:paramtypes", []),
+            __metadata("design:returntype", void 0)
+        ], MetricsProvider.prototype, "reinit", null);
+        return MetricsProvider;
+    }(Script_1.Script));
+    exports.MetricsProvider = MetricsProvider;
+    function createRandomHexString(length) {
+        var characters = '0123456789abcdef';
+        var hexString = '';
+        for (var i = 0; i < length; i++) {
+            var randomIndex = Math.floor(Math.random() * characters.length);
+            hexString += characters.charAt(randomIndex);
+        }
+        return hexString;
+    }
+    function replaceDoubleSlashWSingle(inputString) {
+        var regex = /\/\//g;
+        var resultString = inputString.replace(regex, '/');
+        return resultString;
+    }
+    function log(msg) {
+        if (settings.LOGGING_ENABLED)
+            console.log(msg);
+    }
+    var TrackedSpot = (function () {
+        function TrackedSpot(trackedSpot, owner) {
+            this.trackedSpot = trackedSpot;
+            this.owner = owner;
+            this.trackedSpotName = "";
+            this.hasAttractor = false;
+            this.userID = "";
+            this.currentLanguage = "";
+            log("Tracked spot created " + this.trackedSpot.fullName);
+            this.trackedSpotName = this.trackedSpot.fullName;
+            this.hookUpSources();
+        }
+        TrackedSpot.prototype.onPropChanged = function (sender, message) {
+            switch (message.type) {
+                case "DefaultBlock":
+                    log("Handling DefaultBlock message");
+                    this.onPropDefaultBlockChanged();
+                    break;
+                case "PriorityBlock":
+                    log("Handling PriorityBlock message");
+                    this.onPropPriorityBlockChanged();
+                    break;
+                case "PlayingBlock":
+                    log("Handling PlayingBlock message");
+                    this.onPropPlayingBlockChanged();
+                    break;
+                case "InputSource":
+                    log("Handling InputSource message");
+                    this.onPropInputSourceChanged();
+                    break;
+                case "Volume":
+                    log("Handling Volume message");
+                    this.onPropVolumeChanged();
+                    break;
+                case "Active":
+                    log("Handling Active message");
+                    this.onPropActiveChanged();
+                    break;
+                case "Playing":
+                    log("Handling Playing message");
+                    this.onPropPlayingChanged();
+                    break;
+                case "TagSet":
+                    log("Handling TagSet message");
+                    this.onPropTagSetChanged(sender);
+                    break;
+                default:
+                    console.error("Unexpected message type: ", message.type);
+                    break;
+            }
+        };
+        TrackedSpot.prototype.onPropDefaultBlockChanged = function () {
+        };
+        TrackedSpot.prototype.onPropPriorityBlockChanged = function () {
+        };
+        TrackedSpot.prototype.onPropPlayingBlockChanged = function () {
+            this.hasAttractor = false;
+            var trackedPath = settings.TRACKED_URL + "/" + this.trackedSpot.fullName + "/" + this.trackedSpot.playingBlock + "/" + (this.currentLanguage ? this.currentLanguage : "");
+            var actionName = this.trackedSpot.playingBlock;
+            if (!actionName) {
+                actionName = "No_block_playing";
+            }
+            this.owner.createMatomoMsg(actionName, trackedPath, this.userID);
+        };
+        TrackedSpot.prototype.onPropInputSourceChanged = function () {
+        };
+        TrackedSpot.prototype.onPropVolumeChanged = function () {
+        };
+        TrackedSpot.prototype.onPropActiveChanged = function () {
+            if (this.trackedSpot.active) {
+                this.hasAttractor = true;
+                this.userID = createRandomHexString(16);
+                log("New user created: " + this.userID);
+            }
+        };
+        TrackedSpot.prototype.onPropPlayingChanged = function () {
+        };
+        TrackedSpot.prototype.onPropTagSetChanged = function (sender) {
+            var _this = this;
+            var tags = sender.tagSet.split(",");
+            var foundMatch = false;
+            tags.forEach(function (tag) {
+                var mappedFullName = _this.owner.getTagMappedFullName(tag.trim());
+                if (mappedFullName !== undefined) {
+                    foundMatch = true;
+                    _this.currentLanguage = mappedFullName;
+                }
+                else if (!foundMatch)
+                    _this.currentLanguage = "";
+            });
+        };
+        TrackedSpot.prototype.onNavigation = function (sender, message) {
+            log("Got some navigation data " + message.foundPath);
+            var trackedPath = settings.TRACKED_URL + "/" + sender.fullName + "/" + this.trackedSpot.playingBlock + "/" + (this.currentLanguage ? this.currentLanguage : "") + replaceDoubleSlashWSingle(message.foundPath);
+            var actionName = this.trackedSpot.playingBlock + replaceDoubleSlashWSingle(message.foundPath);
+            this.owner.createMatomoMsg(actionName, trackedPath, this.userID);
+        };
+        TrackedSpot.prototype.onConnectChanged = function (sender, message) {
+            log("Connection changed");
+        };
+        TrackedSpot.prototype.trackedSpotFinished = function () {
+            log("Spot finshed: " + this.trackedSpotName);
+            this.owner.recreateTrackedSpot(this.trackedSpotName);
+        };
+        TrackedSpot.prototype.hookUpSources = function () {
+            var _this = this;
+            this.trackedSpot.subscribe('navigation', function (sender, message) { return _this.onNavigation(sender, message); });
+            this.trackedSpot.subscribe('spot', function (sender, message) { return _this.onPropChanged(sender, message); });
+            this.trackedSpot.subscribe('connect', function (sender, message) { return _this.onConnectChanged(sender, message); });
+            this.trackedSpot.subscribe('finish', function () { return _this.trackedSpotFinished(); });
+        };
+        return TrackedSpot;
+    }());
+});

--- a/user-archive/MetricsProvider.ts
+++ b/user-archive/MetricsProvider.ts
@@ -1,0 +1,393 @@
+/**A user script that allows us to collect various usage aspect of blocks and send that data on to Matomo for analysis 
+ * Make sure the credentials and settings is provided in a config file in script/files/
+ * The script will generate an example config file for your convienience.
+*/
+
+import {Spot, DisplaySpot, SpotGroup} from "system/Spot";
+import {Script, ScriptEnv} from "system_lib/Script";
+import {SimpleHTTP} from "system/SimpleHTTP";
+import { SimpleFile} from "system/SimpleFile";
+import * as Meta from "system_lib/Metadata";
+
+
+//Some default settings to use if config has not been provided
+const DEFAULT_SETTINGS: MatricsProviderSettings = {
+    LOGGING_ENABLED:false, //verbose logging
+    SYSTEM_NAME: "PIXILAB",
+    COUNTRY:"Sweden",
+    CITY:"Linkoping",
+    TRACKER_URL:"https://yourdomain/matomo.php",
+    TRACKED_URL:"http://your_blocks_server",
+    ACCESS_TOKEN:"",
+    SITE_ID: 1,
+    MAX_QUEUE_LENGTH: 50,  //Messages before sending to Matomo
+    MAX_SEND_INTERVALL:1000*60, //After 60 Seconds we send anyway.
+    LANGUAGE_TAG_MAPPING:{
+        se:"Swedish",
+        en:"English",
+        es:"Spanish",
+        de:"German"
+    }
+}
+const API_VERSION = 1; //Script is targetting v.1 Do not change... 
+const CONFIG_FILE = "MetricsProviderSettings.json";
+var settings:MatricsProviderSettings = DEFAULT_SETTINGS;
+
+export class MetricsProvider extends Script {
+
+    private messageInterval?: CancelablePromise<void>;
+    public constructor(env : ScriptEnv) {
+        super(env);
+        this.readSettingsFromFile(); //Get things going..
+       
+    }
+    /**Looking for a settings file, if not present we create one from default settings to use as an example. */
+    private readSettingsFromFile(){
+        SimpleFile.readJson(CONFIG_FILE).then(data => {
+			try {
+				settings = data;
+                if (settings){
+				    this.getAllSpots(Spot); //If we got settings we move on
+                }
+			} catch (parseError) {
+				console.error("Failed parsing JSON data from file", CONFIG_FILE, parseError);
+			}
+		}).catch(	// Failed reading file. Try wo write example file.
+			error => {
+				console.log(error + " Could not find config, trying to write example file to script/files/ " + CONFIG_FILE)
+                SimpleFile.write(CONFIG_FILE + ".example", JSON.stringify(DEFAULT_SETTINGS, null, 2)) //stringify parameters to prettify the settings file
+                .then(() => {
+                  
+                    console.log("Example config file with default values written successfully");
+                    this.readSettingsFromFile();
+                })
+                .catch(error => {
+                 
+                    console.error("Failed writing file:", CONFIG_FILE, error);
+                });
+            }
+		);
+    }
+    private messageQueue: MatomoBulkMessage = {
+        requests:[],
+        token_auth:settings.ACCESS_TOKEN
+    };  
+  
+   /**Finds all assigned spots in the system and start tracking them. 
+    **/
+    private getAllSpots(spotGroup:SpotGroup){
+    let spotGroupItems = spotGroup
+        for (let item in spotGroupItems) {
+            let spotGroupItem = spotGroupItems[item];
+            const displaySpot = spotGroupItem.isOfTypeName("DisplaySpot")
+            if (displaySpot){
+                log("Found displayspot: " + spotGroupItem.fullName)
+                new TrackedSpot(spotGroupItem, this);
+            } else {
+                const spotGroup = spotGroupItem.isOfTypeName("SpotGroup")
+                if (spotGroup) {
+                    log("Found spotgroup: " + spotGroupItem.fullName + " find spots recursive")
+                    this.getAllSpots(spotGroupItem)
+                } 
+            }
+        }
+    }
+    /**Recreate a spot that got the finish event from its previous name i.e. from a setting change.
+     **/
+    recreateTrackedSpot(spotPath:string){
+       const spotPathWithoutSpot = spotPath.replace(/^Spot\./, '');
+        if (Spot[spotPathWithoutSpot]){
+            log("Recreated spot: " + spotPathWithoutSpot)
+            new TrackedSpot(Spot[spotPathWithoutSpot], this);   
+        } 
+    }
+  
+    /**Return current time in hour minutes seconds as separate parameters 
+    */
+    private  getCurrentTime(): { h: number; m: number; s: number } {
+            const now = new Date();
+            const hours = now.getHours();
+            const minutes = now.getMinutes();
+            const seconds = now.getSeconds();
+        
+            return { h: hours, m: minutes, s: seconds };
+        }
+
+    /**Format a tracking message that fit Matomo
+    */
+    createMatomoMsg(actionName:string, url:string, id:string){
+        let time:TimeStamp = this.getCurrentTime()
+        let message:MatomoMessage = {
+                idsite: settings.SITE_ID,
+                rec: 1, 
+                action_name: actionName,
+                url: url,
+                cid: id, 
+                rand: Math.floor(Math.random() * 10000),
+                apiv: API_VERSION, 
+                h: time.h, 
+                m: time.m, 
+                s:time.s,   
+        }     
+        this.queueMessage(message)    
+    }
+    
+    /**We queue up some messages before we send them on to optimise communication*/
+    private queueMessage(message:MatomoMessage){
+        const newMessage = '?' + Object.keys(message)
+        .map(key => `${key}=${message[key]}`)
+        .join('&');
+        this.messageQueue.requests.push(newMessage);
+        log("Queued a new message: " + newMessage);
+        log("Queue is now: " + this.messageQueue.requests.length )
+        if (!this.messageInterval) {
+            this.messageInterval = wait(settings.MAX_SEND_INTERVALL);
+            this.messageInterval.then(()=> {
+                this.messageInterval.cancel();
+                this.messageInterval = undefined; 
+                this.sendMessageQueue();
+            });
+        } 
+        if (this.messageQueue.requests.length >= settings.MAX_QUEUE_LENGTH){
+            this.sendMessageQueue();  
+            this.messageQueue.requests=[]; //Clear the queue to allow for new data to arrive.
+             // Cancel and clear out any existing send timer since we just sent what we had.
+            if (this.messageInterval) {
+                this.messageInterval.cancel();
+                this.messageInterval = undefined;
+            }    
+        }   
+    }   
+             
+    async sendMessageQueue () : Promise<any>{   
+        let tempQueue = {...this.messageQueue}
+        this.messageQueue.requests=[] //clear the cue to get ready for any arriving new messages while sending
+        log("Sending outgoing message: " + JSON.stringify(tempQueue));
+        const request = SimpleHTTP.newRequest(settings.TRACKER_URL);
+        return request.post(JSON.stringify(tempQueue), 'application/json')
+        .catch((error) => {
+            console.error("Connection to the tracker failed:", error);
+            //We could consider to write data that could not be sent to file that can be sent later. 
+        });
+    }
+
+    @Meta.callable("Reinitialize script")
+    public reinit(){
+        this.reInitialize();
+    }
+
+    getTagMappedFullName(key: string): string | undefined {
+        const lowercaseKey = key.toLowerCase();
+      
+        if (lowercaseKey in settings.LANGUAGE_TAG_MAPPING) {
+          return settings.LANGUAGE_TAG_MAPPING[lowercaseKey];
+        } else {
+          return undefined;
+        }
+      }
+}
+
+function createRandomHexString(length:number):string{
+    const characters = '0123456789abcdef';
+    let hexString = '';
+  
+    for (let i = 0; i < length; i++) {
+      const randomIndex = Math.floor(Math.random() * characters.length);
+      hexString += characters.charAt(randomIndex);
+    }
+    return hexString;
+}
+
+function replaceDoubleSlashWSingle(inputString: string): string {
+    // Use a regular expression to match two consecutive forward slashes
+    const regex = /\/\//g;
+  
+    // Replace the first occurrence of two consecutive forward slashes with a single forward slash
+    const resultString = inputString.replace(regex, '/');
+  
+    return resultString;
+  }
+
+   
+function log(msg:any){
+    if (settings.LOGGING_ENABLED)
+    	console.log(msg)
+}
+ 
+class TrackedSpot {
+
+    private trackedSpotName : string = "";
+    private hasAttractor : boolean = false;
+    private userID: string = "";
+    private currentLanguage:string ="";
+    constructor (
+        protected readonly trackedSpot : DisplaySpot,  
+        protected readonly owner : MetricsProvider
+    ) {
+        log("Tracked spot created " + this.trackedSpot.fullName);
+        this.trackedSpotName = this.trackedSpot.fullName
+        this.hookUpSources();
+    }
+
+ 
+    
+    private onPropChanged(sender:DisplaySpot,message:any) {
+        switch (message.type) {
+            case "DefaultBlock":
+                log("Handling DefaultBlock message");
+                this.onPropDefaultBlockChanged();
+                break;
+            case "PriorityBlock":
+                log("Handling PriorityBlock message");
+                this.onPropPriorityBlockChanged();
+                break;
+            case "PlayingBlock":
+                log("Handling PlayingBlock message");
+                this.onPropPlayingBlockChanged();
+                break;
+            case "InputSource":
+                log("Handling InputSource message");
+                this.onPropInputSourceChanged();
+                break;
+            case "Volume":
+                log("Handling Volume message");
+                this.onPropVolumeChanged();
+                break;
+            case "Active":
+                log("Handling Active message");
+                this.onPropActiveChanged();
+                break;
+            case "Playing":
+                log("Handling Playing message");
+                this.onPropPlayingChanged();
+                break;
+            case "TagSet":
+                log("Handling TagSet message");
+                this.onPropTagSetChanged(sender)
+                break;
+            default:
+                // Handle unexpected message types
+                console.error("Unexpected message type: ", message.type);
+                break;
+        }
+    }
+    
+
+    private onPropDefaultBlockChanged(){
+
+    }
+    private onPropPriorityBlockChanged(){
+
+    }
+    private onPropPlayingBlockChanged(){
+    this.hasAttractor = false;
+    let trackedPath = settings.TRACKED_URL + "/" + this.trackedSpot.fullName + "/" + this.trackedSpot.playingBlock + "/" + (this.currentLanguage ? this.currentLanguage : "")
+    //If we have a language selected we syntesize it into the full path. 
+    let actionName = this.trackedSpot.playingBlock
+    if (!actionName){
+        actionName="No_block_playing"
+    }
+    this.owner.createMatomoMsg(actionName,trackedPath ,this.userID)
+    }
+    private onPropInputSourceChanged(){
+
+    }
+    private onPropVolumeChanged(){
+
+    }
+    private onPropActiveChanged(){
+        if (this.trackedSpot.active){
+            this.hasAttractor = true; //Set the hasAttractor if we ever see aktive=true since last blockchange
+            this.userID = createRandomHexString(16);//Since we saw active change we assume a new user.
+            log("New user created: " + this.userID);
+        }
+    }
+    private onPropPlayingChanged(){
+
+    }
+    private onPropTagSetChanged(sender:DisplaySpot){
+    let tags=sender.tagSet.split(",")
+    let foundMatch = false
+    tags.forEach((tag) => { //look for tags that has been mapped as language tagsin settings. We assume only one language tag at any given time.
+        let mappedFullName = this.owner.getTagMappedFullName(tag.trim()) //trim off any leading spaces from the tag and get full name.   
+        if (mappedFullName !== undefined){
+            foundMatch = true
+            this.currentLanguage = mappedFullName
+        } else if (!foundMatch)
+        this.currentLanguage = ""
+        
+      });
+    }
+
+    private onNavigation(sender: DisplaySpot, message: {foundPath: string}) : void
+    { // (sender.fullName ? sender.fullName + "/" : "")
+        log("Got some navigation data " + message.foundPath)
+        let trackedPath = settings.TRACKED_URL + "/" + sender.fullName + "/" + this.trackedSpot.playingBlock + "/" + (this.currentLanguage ? this.currentLanguage : "") + replaceDoubleSlashWSingle(message.foundPath)
+        //If we have a language selected we syntesize it into the full path. 
+        let actionName = this.trackedSpot.playingBlock + replaceDoubleSlashWSingle(message.foundPath) 
+        this.owner.createMatomoMsg(actionName,trackedPath , this.userID)
+    }
+         
+    private onConnectChanged(sender:DisplaySpot,message:any):void{
+        log("Connection changed");
+    }
+
+    private trackedSpotFinished(){
+        log("Spot finshed: " + this.trackedSpotName);
+        this.owner.recreateTrackedSpot(this.trackedSpotName);
+    }
+
+    private hookUpSources(): void
+    {
+        this.trackedSpot.subscribe('navigation', (sender, message) => this.onNavigation(sender,message));
+        this.trackedSpot.subscribe('spot', (sender, message) => this.onPropChanged(sender,message));
+        this.trackedSpot.subscribe('connect', (sender, message) => this.onConnectChanged(sender,message));
+        this.trackedSpot.subscribe('finish', () => this.trackedSpotFinished());
+    }  
+     
+ 
+}
+/**https://developer.matomo.org/api-reference/tracking-api*/
+interface MatomoMessage {
+idsite?:number
+rec?:number
+action_name:string
+url?:string 
+_id?:string //hexadecimal string 16 chars
+cid?:string //defined the Visitor ID for this request
+rand?:number //random number for cache busting
+apiv?:number //Set to one (at time of writing)
+h:number //hour
+m:number //minute
+s:number //second
+[key: string]: number | string;
+}
+
+interface TimeStamp{
+    h:number,
+    m:number,
+    s:number
+}
+
+interface MatomoBulkMessage{
+    requests: string[];
+    token_auth: string;
+}
+
+interface MatricsProviderSettings {
+    SYSTEM_NAME:string
+    COUNTRY:string,
+    CITY:string,
+    LOGGING_ENABLED: boolean,
+    TRACKER_URL:string,
+    TRACKED_URL:string
+    ACCESS_TOKEN:string,
+    SITE_ID:number,
+    MAX_QUEUE_LENGTH:number,
+    MAX_SEND_INTERVALL:number,
+    LANGUAGE_TAG_MAPPING: Record<string, string>;
+}
+interface Vistor {
+    userId:string,
+    selectedLanguage:String
+}


### PR DESCRIPTION
A user script that can send metrics about spot, block, navigation, and language utilization to Matomo for analytics.