### PR TITLE
Silence TS stricts errors

### DIFF
--- a/driver-archive/AnthemMRX_x20.ts
+++ b/driver-archive/AnthemMRX_x20.ts
@@ -405,7 +405,7 @@ export class AnthemMRX_x20 extends NetworkProjector {
 			if (this.recentCmdHoldoff)
 				this.recentCmdHoldoff.cancel();
 			this.recentCmdHoldoff = wait(10000);
-			this.recentCmdHoldoff.then(() => this.recentCmdHoldoff = undefined);
+			this.recentCmdHoldoff.then((): CancelablePromise<void> => this.recentCmdHoldoff = undefined);
 		}
 		return didSend;
 	}
@@ -415,7 +415,7 @@ export class AnthemMRX_x20 extends NetworkProjector {
     private projectorBusy() {
 		if (!this.busyHoldoff) {
 			this.busyHoldoff = wait(4000);
-			this.busyHoldoff.then(() => this.busyHoldoff = undefined);
+			this.busyHoldoff.then((): CancelablePromise<void> => this.busyHoldoff = undefined);
 		}
 	}
 	protected okToSendCommand(): boolean {

--- a/driver/PJLink.ts
+++ b/driver/PJLink.ts
@@ -141,7 +141,7 @@ export class PJLink extends NetworkProjector {
 			if (this.recentCmdHoldoff)
 				this.recentCmdHoldoff.cancel();
 			this.recentCmdHoldoff = wait(10000);
-			this.recentCmdHoldoff.then(() => this.recentCmdHoldoff = undefined);
+			this.recentCmdHoldoff.then((): CancelablePromise<void> => this.recentCmdHoldoff = undefined);
 		}
 		return didSend;
 	}
@@ -266,7 +266,7 @@ export class PJLink extends NetworkProjector {
 	private projectorBusy() {
 		if (!this.busyHoldoff) {
 			this.busyHoldoff = wait(4000);
-			this.busyHoldoff.then(() => this.busyHoldoff = undefined);
+			this.busyHoldoff.then((): CancelablePromise<void> => this.busyHoldoff = undefined);
 		}
 	}
 

--- a/driver/PJLinkPlus.ts
+++ b/driver/PJLinkPlus.ts
@@ -1331,7 +1331,7 @@ export class PJLinkPlus extends NetworkProjector {
     private projectorBusy() {
 		if (!this.busyHoldoff) {
 			this.busyHoldoff = wait(4000);
-			this.busyHoldoff.then(() => this.busyHoldoff = undefined);
+			this.busyHoldoff.then((): CancelablePromise<void> => this.busyHoldoff = undefined);
 		}
 	}
 


### PR DESCRIPTION
error: TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type. The TS compiler is set to strict by tsconfig default option being noImplicitAny fix: add explicit return type annotations to Promise callbacks