### PR TITLE
Fix mute changing volume and init modifying state.

### DIFF
--- a/driver-archive/GenelecSmartIP.js
+++ b/driver-archive/GenelecSmartIP.js
@@ -32,8 +32,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 var __generator = (this && this.__generator) || function (thisArg, body) {
-    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
-    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g = Object.create((typeof Iterator === "function" ? Iterator : Object).prototype);
+    return g.next = verb(0), g["throw"] = verb(1), g["return"] = verb(2), typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
     function verb(n) { return function (v) { return step([n, v]); }; }
     function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
@@ -58,11 +58,11 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", "../system_lib/Metadata"], function (require, exports, SimpleHTTP_1, Driver_1, Metadata_1) {
+define(["require", "exports", "system/SimpleHTTP", "system_lib/Driver", "system_lib/Metadata"], function (require, exports, SimpleHTTP_1, Driver_1, Metadata_1) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     exports.GenelecSmartIP = void 0;
-    var GenelecSmartIP = exports.GenelecSmartIP = (function (_super) {
+    var GenelecSmartIP = (function (_super) {
         __extends(GenelecSmartIP, _super);
         function GenelecSmartIP(socket) {
             var _this = _super.call(this, socket) || this;
@@ -136,8 +136,10 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                         case 1:
                             response = _a.sent();
                             data = response.interpreted;
-                            this.volume = this.dbToNorm(data.level);
-                            this.mute = data.mute;
+                            this._volume = this.dbToNorm(data.level);
+                            this._mute = data.mute;
+                            this.changed("volume");
+                            this.changed("mute");
                             return [3, 3];
                         case 2:
                             err_1 = _a.sent();
@@ -159,7 +161,8 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                         case 1:
                             response = _a.sent();
                             data = response.interpreted;
-                            this.active = (data.state === "ACTIVE");
+                            this._active = data.state === "ACTIVE";
+                            this.changed("active");
                             return [3, 3];
                         case 2:
                             err_2 = _a.sent();
@@ -181,7 +184,8 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                         case 1:
                             response = _a.sent();
                             data = response.interpreted;
-                            this.profile = data.selected;
+                            this._profile = data.selected;
+                            this.changed("profile");
                             return [3, 3];
                         case 2:
                             err_3 = _a.sent();
@@ -282,8 +286,8 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                 if (this._mute !== value && this._active) {
                     var endPoint = "audio/volume";
                     var payload = {
-                        level: this._volume,
-                        mute: value
+                        level: this.normToDb_linearInDb(this._volume),
+                        mute: value,
                     };
                     this.sendCommand(endPoint, payload);
                     this._mute = value;
@@ -299,7 +303,7 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
             set: function (value) {
                 var endPoint = "device/pwr";
                 var payload = {
-                    state: value ? "ACTIVE" : "STANDBY"
+                    state: value ? "ACTIVE" : "STANDBY",
                 };
                 this.sendCommand(endPoint, payload);
                 this._active = value;
@@ -317,7 +321,7 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                     var endPoint = "audio/volume";
                     var payload = {
                         level: this.normToDb_linearInDb(value),
-                        mute: this._mute
+                        mute: this._mute,
                     };
                     this.sendCommand(endPoint, payload);
                     this._volume = value;
@@ -335,7 +339,7 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                     var endPoint = "profile/restore";
                     var payload = {
                         id: value,
-                        startup: true
+                        startup: true,
                     };
                     this.sendCommand(endPoint, payload);
                     this._profile = value;
@@ -417,7 +421,7 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
         };
         GenelecSmartIP.prototype.sendCommand = function (endPoint, payload) {
             return __awaiter(this, void 0, void 0, function () {
-                var response, err_7;
+                var err_7;
                 return __generator(this, function (_a) {
                     switch (_a.label) {
                         case 0:
@@ -428,14 +432,13 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                             _a.label = 1;
                         case 1:
                             _a.trys.push([1, 3, , 4]);
-                            return [4, SimpleHTTP_1.SimpleHTTP
-                                    .newRequest("http://".concat(this.socket.address, ":").concat(this.socket.port, "/public/v1/").concat(endPoint))
+                            return [4, SimpleHTTP_1.SimpleHTTP.newRequest("http://".concat(this.socket.address, ":").concat(this.socket.port, "/public/v1/").concat(endPoint))
                                     .header("Authorization", this.auth)
                                     .put(JSON.stringify(payload))];
                         case 2:
-                            response = _a.sent();
+                            _a.sent();
                             this.connected = true;
-                            return [2, response];
+                            return [3, 4];
                         case 3:
                             err_7 = _a.sent();
                             this.connected = false;
@@ -453,13 +456,12 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                         case 0:
                             if (!this.socket.enabled) {
                                 this.connected = false;
-                                return [2];
+                                return [2, undefined];
                             }
                             _a.label = 1;
                         case 1:
                             _a.trys.push([1, 3, , 4]);
-                            return [4, SimpleHTTP_1.SimpleHTTP
-                                    .newRequest("http://".concat(this.socket.address, ":").concat(this.socket.port, "/public/v1/").concat(endPoint), { interpretResponse: true })
+                            return [4, SimpleHTTP_1.SimpleHTTP.newRequest("http://".concat(this.socket.address, ":").concat(this.socket.port, "/public/v1/").concat(endPoint), { interpretResponse: true })
                                     .header("Authorization", this.auth)
                                     .get()];
                         case 2:
@@ -470,7 +472,7 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                             err_8 = _a.sent();
                             console.error("Request failed:", err_8);
                             this.connected = false;
-                            return [3, 4];
+                            return [2, undefined];
                         case 4: return [2];
                     }
                 });
@@ -497,8 +499,12 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
                 var e1 = c1 >> 2;
                 var e2 = ((c1 & 3) << 4) | (c2 >> 4);
                 var e3 = isNaN(c2) ? 64 : ((c2 & 15) << 2) | (c3 >> 6);
-                var e4 = isNaN(c2) || isNaN(c3) ? 64 : (c3 & 63);
-                result += chars.charAt(e1) + chars.charAt(e2) + (e3 === 64 ? "=" : chars.charAt(e3)) + (e4 === 64 ? "=" : chars.charAt(e4));
+                var e4 = isNaN(c2) || isNaN(c3) ? 64 : c3 & 63;
+                result +=
+                    chars.charAt(e1) +
+                        chars.charAt(e2) +
+                        (e3 === 64 ? "=" : chars.charAt(e3)) +
+                        (e4 === 64 ? "=" : chars.charAt(e4));
             }
             return result;
         };
@@ -557,9 +563,10 @@ define(["require", "exports", "../system/SimpleHTTP", "../system_lib/Driver", ".
             __metadata("design:paramtypes", [String])
         ], GenelecSmartIP.prototype, "aoipName", null);
         GenelecSmartIP = __decorate([
-            (0, Metadata_1.driver)('NetworkTCP', { port: 9000 }),
+            (0, Metadata_1.driver)("NetworkTCP", { port: 9000 }),
             __metadata("design:paramtypes", [Object])
         ], GenelecSmartIP);
         return GenelecSmartIP;
     }(Driver_1.Driver));
+    exports.GenelecSmartIP = GenelecSmartIP;
 });

--- a/driver-archive/GenelecSmartIP.ts
+++ b/driver-archive/GenelecSmartIP.ts
@@ -1,6 +1,6 @@
 /**
  * Driver to control Genelec Smart IP speaker series (api v1)
- * 
+ *
  * Copyright (c) PIXILAB Technologies AB, Sweden (http://pixilab.se). All Rights Reserved.
  * Created 2025 by Mattias Andersson.
  * The driver does not support automatic ISS (Intelligent Signal Sensing) sleep power saving feature
@@ -9,355 +9,358 @@
  * At Blocks server restart the current settings will be read back from the speaker.
  * Credential is added as a driver options e.g. admin:admin
  * @version 1.01
- * 
+ *
  */
 
-import { NetworkTCP } from "../system/Network";
-import { SimpleHTTP } from "../system/SimpleHTTP";
-import { Driver } from "../system_lib/Driver";
-import { driver, min,max, property } from "../system_lib/Metadata";
+import { NetworkTCP } from "system/Network";
+import { SimpleHTTP } from "system/SimpleHTTP";
+import { Driver } from "system_lib/Driver";
+import { driver, min, max, property } from "system_lib/Metadata";
 
-
-@driver('NetworkTCP', { port:9000 })
+@driver("NetworkTCP", { port: 9000 })
 export class GenelecSmartIP extends Driver<NetworkTCP> {
-    
-    private _mute:boolean = false
-    private _volume: number = 0
-    private _profile: number = 0
-    private _connected:boolean = false
-    private _zone:string = ""
-    private _active:boolean = false
-    private _aoipName:string = ""
-    private _enableAoIP01 = false
-    private _enableAoIP02 = false
-    private _enableAnalog = false
-    private _hasAnalog = false
-    private auth:string
-    
+  private _mute: boolean = false;
+  private _volume: number = 0;
+  private _profile: number = 0;
+  private _connected: boolean = false;
+  private _zone: string = "";
+  private _active: boolean = false;
+  private _aoipName: string = "";
+  private _enableAoIP01: boolean = false;
+  private _enableAoIP02: boolean = false;
+  private _enableAnalog: boolean = false;
+  private _hasAnalog: boolean = false;
+  private auth: string;
 
+  public constructor(private socket: NetworkTCP) {
+    super(socket);
 
-    public constructor(
-        private socket: NetworkTCP
-    ){
-            super(socket)
-            
-     if (socket.enabled) {
-        if (socket.options && socket.options.trim() !== "") {
-            // Always include a space after "Basic"
-            this.auth = "Basic " + this.toBase64(socket.options);
-        } else {
-            console.warn("No credentials in driver options, trying default");
-            // Make sure to include the space after "Basic"
-            this.auth = "Basic YWRtaW46YWRtaW4="; // default admin:admin
-        }
+    if (socket.enabled) {
+      if (socket.options && socket.options.trim() !== "") {
+        // Always include a space after "Basic"
+        this.auth = "Basic " + this.toBase64(socket.options);
+      } else {
+        console.warn("No credentials in driver options, trying default");
+        // Make sure to include the space after "Basic"
+        this.auth = "Basic YWRtaW46YWRtaW4="; // default admin:admin
+      }
 
-
-        this.initStatus();  
-        
-        }
+      this.initStatus();
     }
-    /* Read back current settings from the speaker at driver/server startup */
-    private async initStatus() {
+  }
+  /* Read back current settings from the speaker at driver/server startup */
+  private async initStatus() {
     try {
-        await this.getPowerStatus();
-        await this.getVolumeLevel();
-        await this.getProfileList();
-        await this.getZone();
-        await this.getAOIPName();
-        await this.getInputSources()
-
+      await this.getPowerStatus();
+      await this.getVolumeLevel();
+      await this.getProfileList();
+      await this.getZone();
+      await this.getAOIPName();
+      await this.getInputSources();
     } catch (error) {
-        console.error("Error during initStatus:", error);
-        
+      console.error("Error during initStatus:", error);
     }
-}
-    private async getVolumeLevel(){
-        try {
-            const response  = await this.sendRequest("audio/volume") ;
-            const data = response.interpreted as AudioStatus;
-            this.volume = this.dbToNorm(data.level)
-            this.mute = data.mute
-        } catch (err) {
-            console.error("Failed to fetch initial volume:", err);
-        }
+  }
+  private async getVolumeLevel() {
+    try {
+      const response = await this.sendRequest("audio/volume");
+      const data = response.interpreted as AudioStatus;
+      this._volume = this.dbToNorm(data.level);
+      this._mute = data.mute;
+      this.changed("volume");
+      this.changed("mute");
+    } catch (err) {
+      console.error("Failed to fetch initial volume:", err);
     }
-
-    private async getPowerStatus() {
-        try {
-            const response  = await this.sendRequest("device/pwr") ;
-            const data = response.interpreted as DevicePowerStatus;
-            this.active = (data.state === "ACTIVE") 
-        } catch (err) {
-            console.error("Failed to fetch initial power:", err);
-        }
-    }
-  
-    private async getProfileList() {
-        try {
-            const response  = await this.sendRequest("profile/list") ;
-            const data = response.interpreted as ProfileStatus;
-            this.profile = data.selected
-        } catch (err) {
-            console.error("Failed to fetch initial profile:", err);
-        }
-    }  
-
-    private async getZone() {
-        try {
-            const response  = await this.sendRequest("network/zone") ;
-            const data = response.interpreted as Zone;
-            this.zone = data.name
-        } catch (err) {
-            console.error("Failed to fetch initial zone:", err);
-        }
-    } 
-
-    private async getAOIPName() {
-        try {
-            const response  = await this.sendRequest("aoip/dante/identity") ;
-            const data = response.interpreted as AoipIdentity;
-            this.aoipName = data.fname
-        } catch (err) {
-            console.error("Failed to fetch initial zone:", err);
-        }
-    }
-
-    private async getInputSources() {
-        try {
-            const response  = await this.sendRequest("audio/inputs") ;
-            const data = response.interpreted as Inputs;
-            data.input.forEach(input => {
-                if (input === "A") { //Can we do analog in this one?
-                    this._hasAnalog = true;
-                    this._enableAnalog = true;
-                }
-            });
-        } catch (err) {
-            console.error("Failed to fetch initial zone:", err);
-        }
-    }   
-
-    @property("Device connected status", true)
-        get connected(): boolean {
-            return this._connected;
-        }
-        set connected(value: boolean) {
-            this._connected = value;
-        }
-
-    @property("Mute the speaker")
-        get mute(): boolean {
-            return this._mute
-        }
-        set mute(value: boolean) {
-            if (this._mute !== value && this._active){
-            const endPoint  = "audio/volume"
-            const payload  = {
-            level: this._volume,   
-            mute: value
-             };
-            this.sendCommand(endPoint,payload)   
-            this._mute = value
-        }
-    }
-
-    @property("Device Active")
-        get active(): boolean {
-            return this._active
-        }
-        set active(value: boolean) {
-            const endPoint = "device/pwr"
-            const payload  = {
-            state: value ? "ACTIVE" : "STANDBY"  
-             };
-            this.sendCommand(endPoint,payload)   
-            this._active = value
-            this.mute = false
-            
-        }    
-
-    @property("Normalized volume") @min(0) @max(1)
-        get volume(): number {
-            return this._volume
-        }
-        set volume(value: number) {
-            if (this._volume !== value && this._active ){
-                const endPoint = "audio/volume"
-                const payload  = {
-                level: this.normToDb_linearInDb(value),   
-                mute: this._mute 
-                }; 
-                this.sendCommand(endPoint,payload)
-                this._volume = value
-            }
-        }
-    @property("Speaker profile") @min(0) @max(5)
-        get profile(): number {
-            return this._profile
-        }
-        set profile(value: number) {
-            if (this._profile !== value && this._active){
-                const endPoint = "profile/restore"
-                const payload  = {
-                id: value,
-                startup: true   //Driver always set as startup profile
-                };
-                this.sendCommand(endPoint,payload)
-                this._profile = value
-            }
-        }
-    @property("Enable AoIP01 source")
-        get enableAoIP01(): boolean {
-            return this._enableAoIP01
-        }
-        set enableAoIP01(value: boolean) {
-            if (this._enableAoIP01 !== value && this._active){
-                this._enableAoIP01 = value
-                this.sendInputCommand()
-            }
-        }
-
-    @property("Enable AoIP02 source") 
-        get enableAoIP02(): boolean {
-            return this._enableAoIP02
-        }
-        set enableAoIP02(value: boolean) {
-            if (this._enableAoIP02 !== value && this._active){
-                this._enableAoIP02 = value
-                this.sendInputCommand()
-            }
-        }
-
-    @property("Enable Analog source") 
-        get enableAnalog(): boolean {
-            return this._enableAnalog
-        }
-        set enableAnalog(value: boolean) {
-            if (this._enableAnalog !== value && this._active && this._hasAnalog){
-                this._enableAnalog = value
-                this.sendInputCommand()
-            }
-        }
-
-    @property("Zone name",true) 
-        get zone(): string {
-            return this._zone
-        }
-        set zone(value:string){
-            this._zone = value
-        }
-        
-        
-    @property("Speaker AIOP fname",true) 
-        get aoipName(): string {
-            return this._aoipName
-        }
-        set aoipName(value:string){
-            this._aoipName = value
-        }
-    
-    
-private sendInputCommand() {
-  const endPoint = "audio/inputs";
-  const payload = [];
-
-  if (this._enableAoIP01) payload.push("AoIP01");
-  if (this._enableAoIP02) payload.push("AoIP02");
-  if (this._enableAnalog) payload.push("A");
-
-  const cmd = { input: payload };
-  this.sendCommand(endPoint, cmd);
-}
-
-private async sendCommand(endPoint: string, payload: Record<string, unknown>) {
-  if (!this.socket.enabled) {
-    this.connected = false;
-    return;
   }
 
-  try {
-    const response = await SimpleHTTP
-      .newRequest(`http://${this.socket.address}:${this.socket.port}/public/v1/${endPoint}`)
-      .header("Authorization", this.auth)
-      .put(JSON.stringify(payload));
-
-    this.connected = true
-
-    return response;
-    } catch (err) {     
-        this.connected = false
+  private async getPowerStatus() {
+    try {
+      const response = await this.sendRequest("device/pwr");
+      const data = response.interpreted as DevicePowerStatus;
+      this._active = data.state === "ACTIVE";
+      this.changed("active");
+    } catch (err) {
+      console.error("Failed to fetch initial power:", err);
     }
-}
-
-
-private async sendRequest(endPoint: string) {
-  if (!this.socket.enabled) {
-    this.connected = false;
-    return;
   }
 
-  try {
-    const response = await SimpleHTTP
-      .newRequest(`http://${this.socket.address}:${this.socket.port}/public/v1/${endPoint}`, { interpretResponse: true })
-      .header("Authorization", this.auth)
-      .get();
+  private async getProfileList() {
+    try {
+      const response = await this.sendRequest("profile/list");
+      const data = response.interpreted as ProfileStatus;
+      this._profile = data.selected;
+      this.changed("profile");
+    } catch (err) {
+      console.error("Failed to fetch initial profile:", err);
+    }
+  }
 
-     this.connected = true
+  private async getZone() {
+    try {
+      const response = await this.sendRequest("network/zone");
+      const data = response.interpreted as Zone;
+      this.zone = data.name;
+    } catch (err) {
+      console.error("Failed to fetch initial zone:", err);
+    }
+  }
 
-    return response;
-  } catch (err) {
-    console.error("Request failed:", err);
-    this.connected = false
+  private async getAOIPName() {
+    try {
+      const response = await this.sendRequest("aoip/dante/identity");
+      const data = response.interpreted as AoipIdentity;
+      this.aoipName = data.fname;
+    } catch (err) {
+      console.error("Failed to fetch initial zone:", err);
+    }
+  }
+
+  private async getInputSources() {
+    try {
+      const response = await this.sendRequest("audio/inputs");
+      const data = response.interpreted as Inputs;
+      data.input.forEach((input) => {
+        if (input === "A") {
+          //Can we do analog in this one?
+          this._hasAnalog = true;
+          this._enableAnalog = true;
+        }
+      });
+    } catch (err) {
+      console.error("Failed to fetch initial zone:", err);
+    }
+  }
+
+  @property("Device connected status", true)
+  override get connected(): boolean {
+    return this._connected;
+  }
+  override set connected(value: boolean) {
+    this._connected = value;
+  }
+
+  @property("Mute the speaker")
+  get mute(): boolean {
+    return this._mute;
+  }
+  set mute(value: boolean) {
+    if (this._mute !== value && this._active) {
+      const endPoint = "audio/volume";
+      const payload = {
+        level: this.normToDb_linearInDb(this._volume),
+        mute: value,
+      };
+      this.sendCommand(endPoint, payload);
+      this._mute = value;
+    }
+  }
+
+  @property("Device Active")
+  get active(): boolean {
+    return this._active;
+  }
+  set active(value: boolean) {
+    const endPoint = "device/pwr";
+    const payload = {
+      state: value ? "ACTIVE" : "STANDBY",
+    };
+    this.sendCommand(endPoint, payload);
+    this._active = value;
+    this.mute = false;
+  }
+
+  @property("Normalized volume")
+  @min(0)
+  @max(1)
+  get volume(): number {
+    return this._volume;
+  }
+  set volume(value: number) {
+    if (this._volume !== value && this._active) {
+      const endPoint = "audio/volume";
+      const payload = {
+        level: this.normToDb_linearInDb(value),
+        mute: this._mute,
+      };
+      this.sendCommand(endPoint, payload);
+      this._volume = value;
+    }
+  }
+  @property("Speaker profile")
+  @min(0)
+  @max(5)
+  get profile(): number {
+    return this._profile;
+  }
+  set profile(value: number) {
+    if (this._profile !== value && this._active) {
+      const endPoint = "profile/restore";
+      const payload = {
+        id: value,
+        startup: true, //Driver always set as startup profile
+      };
+      this.sendCommand(endPoint, payload);
+      this._profile = value;
+    }
+  }
+  @property("Enable AoIP01 source")
+  get enableAoIP01(): boolean {
+    return this._enableAoIP01;
+  }
+  set enableAoIP01(value: boolean) {
+    if (this._enableAoIP01 !== value && this._active) {
+      this._enableAoIP01 = value;
+      this.sendInputCommand();
+    }
+  }
+
+  @property("Enable AoIP02 source")
+  get enableAoIP02(): boolean {
+    return this._enableAoIP02;
+  }
+  set enableAoIP02(value: boolean) {
+    if (this._enableAoIP02 !== value && this._active) {
+      this._enableAoIP02 = value;
+      this.sendInputCommand();
+    }
+  }
+
+  @property("Enable Analog source")
+  get enableAnalog(): boolean {
+    return this._enableAnalog;
+  }
+  set enableAnalog(value: boolean) {
+    if (this._enableAnalog !== value && this._active && this._hasAnalog) {
+      this._enableAnalog = value;
+      this.sendInputCommand();
+    }
+  }
+
+  @property("Zone name", true)
+  get zone(): string {
+    return this._zone;
+  }
+  set zone(value: string) {
+    this._zone = value;
+  }
+
+  @property("Speaker AIOP fname", true)
+  get aoipName(): string {
+    return this._aoipName;
+  }
+  set aoipName(value: string) {
+    this._aoipName = value;
+  }
+
+  private sendInputCommand() {
+    const endPoint = "audio/inputs";
+    const payload = [];
+
+    if (this._enableAoIP01) payload.push("AoIP01");
+    if (this._enableAoIP02) payload.push("AoIP02");
+    if (this._enableAnalog) payload.push("A");
+
+    const cmd = { input: payload };
+    this.sendCommand(endPoint, cmd);
+  }
+
+  private async sendCommand(
+    endPoint: string,
+    payload: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this.socket.enabled) {
+      this.connected = false;
+      return;
+    }
+
+    try {
+      await SimpleHTTP.newRequest(
+        `http://${this.socket.address}:${this.socket.port}/public/v1/${endPoint}`,
+      )
+        .header("Authorization", this.auth)
+        .put(JSON.stringify(payload));
+
+      this.connected = true;
+    } catch (err) {
+      this.connected = false;
+    }
+  }
+
+  private async sendRequest(endPoint: string): Promise<any> {
+    if (!this.socket.enabled) {
+      this.connected = false;
+      return undefined;
+    }
+
+    try {
+      const response = await SimpleHTTP.newRequest(
+        `http://${this.socket.address}:${this.socket.port}/public/v1/${endPoint}`,
+        { interpretResponse: true },
+      )
+        .header("Authorization", this.auth)
+        .get();
+
+      this.connected = true;
+
+      return response;
+    } catch (err) {
+      console.error("Request failed:", err);
+      this.connected = false;
+      return undefined;
+    }
+  }
+
+  /*  Utility methods */
+
+  private normToDb_linearInDb(v: number): number {
+    const clamped = Math.min(1, Math.max(0, v));
+    const db = -200 + 200 * clamped; // map to [-200, 0]
+    const quantized = Math.round(db * 10) / 10; // 0.1 dB steps
+    return Math.min(0, Math.max(-200, quantized));
+  }
+
+  private dbToNorm(db: number): number {
+    const c = Math.min(0, Math.max(-200, db));
+    return (c + 200) / 200;
+  }
+
+  private toBase64(str: string): string {
+    const chars =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let result = "";
+    let i = 0;
+
+    while (i < str.length) {
+      const c1 = str.charCodeAt(i++);
+      const c2 = str.charCodeAt(i++);
+      const c3 = str.charCodeAt(i++);
+
+      const e1 = c1 >> 2;
+      const e2 = ((c1 & 3) << 4) | (c2 >> 4);
+      const e3 = isNaN(c2) ? 64 : ((c2 & 15) << 2) | (c3 >> 6);
+      const e4 = isNaN(c2) || isNaN(c3) ? 64 : c3 & 63;
+
+      result +=
+        chars.charAt(e1) +
+        chars.charAt(e2) +
+        (e3 === 64 ? "=" : chars.charAt(e3)) +
+        (e4 === 64 ? "=" : chars.charAt(e4));
+    }
+    return result;
   }
 }
-    
-
-   /*  Utility methods */
-
-    private normToDb_linearInDb(v: number): number {
-        const clamped = Math.min(1, Math.max(0, v));
-        const db = -200 + 200 * clamped;          // map to [-200, 0]
-        const quantized = Math.round(db * 10) / 10; // 0.1 dB steps
-        return Math.min(0, Math.max(-200, quantized));
-    }
-    
-    private dbToNorm(db: number): number {
-        const c = Math.min(0, Math.max(-200, db));
-        return (c + 200) / 200;
-        }
-
-    private toBase64(str: string): string {
-        const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-        let result = "";
-        let i = 0;
-
-        while (i < str.length) {
-            const c1 = str.charCodeAt(i++);
-            const c2 = str.charCodeAt(i++);
-            const c3 = str.charCodeAt(i++);
-
-            const e1 = c1 >> 2;
-            const e2 = ((c1 & 3) << 4) | (c2 >> 4);
-            const e3 = isNaN(c2) ? 64 : ((c2 & 15) << 2) | (c3 >> 6);
-            const e4 = isNaN(c2) || isNaN(c3) ? 64 : (c3 & 63);
-
-            result += chars.charAt(e1) + chars.charAt(e2) + (e3 === 64 ? "=" : chars.charAt(e3)) + (e4 === 64 ? "=" : chars.charAt(e4));
-        }
-        return result;
-    }    
-}
-
 
 /* GET device/pwr */
 interface DevicePowerStatus {
-  state: "ACTIVE" | "STANDBY"|"ISS_SLEEP" | "PWR_FAIL" 
+  state: "ACTIVE" | "STANDBY" | "ISS_SLEEP" | "PWR_FAIL";
   poeAllocatedPwr: number;
   poePd15W: boolean;
 }
 
 /* GET audio/volume */
 interface AudioStatus {
-  level: number;   // in dB? (since it's negative)
+  level: number; // in dB? (since it's negative)
   mute: boolean;
 }
 
@@ -385,12 +388,12 @@ interface Zone {
   name: string;
 }
 /* GET aoip identity */
-interface AoipIdentity{
-    id:string;
-    name:string;
-    fname:string;
-    mac: string;
-    locked: boolean;
+interface AoipIdentity {
+  id: string;
+  name: string;
+  fname: string;
+  mac: string;
+  locked: boolean;
 }
 /* GET Input sources available */
 interface Inputs {


### PR DESCRIPTION
1. Mute volume bug — Mute setter was sending the raw normalized value (0..1) as level instead of converting to dB via normToDb_linearInDb. A mute toggle could set the speaker to near-full volume.
2. Reading status on init was sending commands to speaker — getVolumeLevel, getPowerStatus, and getProfileList all used property setters which sent PUT requests back to the device on startup. In some cases also changing the device state (e.g. getPowerStatus unmuted the speaker and getVolumeLevel triggered mute which in turn changed volume due to the above bug), Now they write to backing fields directly and call changed().
3. Various minor consistency and formatting cleaned up.